### PR TITLE
Improved hit rate on Bio's

### DIFF
--- a/src/js/form/alternate_names.js
+++ b/src/js/form/alternate_names.js
@@ -7,7 +7,7 @@ export default {
         level: ['audience'],
         type: ['talk type', 'categoria'],
         slides: ['slides', 'slides url'],
-        body: ['bio', 'about you', 'biography']
+        body: ['bio', 'about you', 'biography', 'speaker bio']
     },
 
     alternateOptions: {


### PR DESCRIPTION
Turns out `bio` is a small word that even if matched with `bio` will only return a fuzzy result of 11, which is cut off by our algorightm as being too low.
For this reason the bio field was not filled if its just called `bio`.
Added `Speaker Bio` as an alternate name and this makes it get 4K+ results.

Closes #21 and Closes #32.
